### PR TITLE
Add pronouns (#16)

### DIFF
--- a/layouts/header.typ
+++ b/layouts/header.typ
@@ -1,3 +1,18 @@
+// Pronouns
+#let pronouns-text(data, settings) = {
+    if ("pronouns" in data.personal and data.personal.pronouns != none) {
+        context {
+            place(
+                center + horizon,
+                dx: measure[#data.personal.name].width / 2 + 1.8em,
+                text(weight: "light", size: settings.fontsize)[
+                    (#data.personal.pronouns)
+                ]
+            )
+        }
+    } else {none}
+}
+
 // Job titles
 #let jobtitle-text(data, settings) = {
     if ("titles" in data.personal and data.personal.titles != none) {
@@ -48,9 +63,8 @@
 
 
 #let layout-header(data, settings, isbreakable: true) = {
-
     align(center)[
-        = #data.personal.name
+        = #data.personal.name #pronouns-text(data, settings)
 
         #for section in data.sections.filter(s => s.layout == "header" and s.show == true) {
             if "include" in section {

--- a/layouts/header.typ
+++ b/layouts/header.typ
@@ -1,13 +1,17 @@
 // Pronouns
 #let pronouns-text(data, settings) = {
     if ("pronouns" in data.personal and data.personal.pronouns != none) {
+        let pronouns = text(
+            weight: "light",
+            fill: luma(50),
+            size: settings.fontsize - 1pt,
+        )[(#data.personal.pronouns)]
         context {
             place(
                 center + horizon,
-                dx: measure[#data.personal.name].width / 2 + 1.8em,
-                text(weight: "light", size: settings.fontsize)[
-                    (#data.personal.pronouns)
-                ]
+                dx: measure[#data.personal.name].width / 2 
+                    + measure[#pronouns].width / 2 + 0.4em,
+                pronouns
             )
         }
     } else {none}

--- a/template/template.yml
+++ b/template/template.yml
@@ -19,6 +19,7 @@ settings:
 # Personal information
 personal:
   name: John Doe
+  pronouns: he / they
   titles:
     - Senior Data Scientist
     - Machine Learning Specialist


### PR DESCRIPTION
Add an optional pronouns field.

Pronouns are displayed in parenthesis, next to the name, in normal text size and light weight.  
The name stays centered (adding pronouns doesn't change name position).

Implements #16.